### PR TITLE
Added link to honeyswap

### DIFF
--- a/src/components/Footer/components/Nav.tsx
+++ b/src/components/Footer/components/Nav.tsx
@@ -8,17 +8,20 @@ const Nav: React.FC = () => {
       <StyledHeader>
         Community
       </StyledHeader>
-      <Link href="https://discord.gg/qPa4h5w" external>
-        Discord
-      </Link>
       <Link href="https://github.com/1Hive" external>
         Github
+      </Link>
+      <Link href="https://discord.gg/wcNg589r" external>
+        Help
+      </Link>
+      <Link href="https://forum.1hive.org/" external>
+        Forum
       </Link>
       <Link href="https://twitter.com/1HiveOrg" external>
         Twitter
       </Link>
-      <Link href="https://forum.1hive.org/" external>
-        Forum
+      <Link href="https://t.me/honeyswapdex" external>
+        Telegram
       </Link>
     </div>
   )

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -26,7 +26,7 @@ const Home: React.FC = () => {
           margin: '0 auto',
         }}
       >
-        <Button text="Explore the Honeycomb" to="/farms" variant="secondary" />
+        <Button text="Back to Honeyswap" href="https://honeyswap.org/#/swap" variant="default" />
       </div>
     </Page>
   )


### PR DESCRIPTION
changed 'explore honeycomb' link to provide link to honeyswap since there is already a 'home, farm, and create farm' link at top. Also, added telegram link and renamed discord help. changed order of the links to match 1hive about page.
![image](https://user-images.githubusercontent.com/73294662/100168946-4e5fc680-2e90-11eb-842f-7605cb46b55b.png)
